### PR TITLE
Remove note about unit of `fovy`

### DIFF
--- a/04-maths.rst
+++ b/04-maths.rst
@@ -437,14 +437,14 @@ field of view in the horizontal and vertical direction:
 
    ┌                                     ┐ n: near
    │ c/aspect  0       0          0      │ f: far
-   │    0      c       0          0      │ c : cotangen(fovy)
+   │    0      c       0          0      │ c: cotangent(fovy)
    │    0      0  (f+n)/(n-f)  2nf/(n-f) │ 
    │    0      0      -1          0      │ 
    └                                     ┘ 
                Perspective projection
 
                
-where `fovy` specifies the field of view angle, in degrees, in the y direction
+where `fovy` specifies the field of view angle in the y direction
 and `aspect` specifies the aspect ratio that determines the field of view in
 the x direction.
 


### PR DESCRIPTION
Typo fix: `cotangen` → `cotangent`

Now, `fovy` is only used in `cotangent(fovy)`. The text doesn't mention any specific implementation for `cotangent`. The mathematical function just takes an angle.
When implementing this, `fovy` should be in whatever units the `cotangent` implementation uses – but that can go without saying.