### PR TITLE
Update Glut window to use glutDestroyWindow

### DIFF
--- a/03-quickstart.rst
+++ b/03-quickstart.rst
@@ -200,29 +200,35 @@ package. Here is a minimal setup that should open a window with a black backgrou
 
 .. code:: python
 
-   import sys
    import OpenGL.GL as gl
    import OpenGL.GLUT as glut
+
+   window = None
+
 
    def display():
        gl.glClear(gl.GL_COLOR_BUFFER_BIT)
        glut.glutSwapBuffers()
 
-   def reshape(width,height):
+
+   def reshape(width, height):
        gl.glViewport(0, 0, width, height)
 
-   def keyboard( key, x, y ):
-       if key == b'\x1b':
-           sys.exit( )
 
-   glut.glutInit()
-   glut.glutInitDisplayMode(glut.GLUT_DOUBLE | glut.GLUT_RGBA)
-   glut.glutCreateWindow('Hello world!')
-   glut.glutReshapeWindow(512,512)
-   glut.glutReshapeFunc(reshape)
-   glut.glutDisplayFunc(display)
-   glut.glutKeyboardFunc(keyboard)
-   glut.glutMainLoop()
+   def keyboard(key, x, y):
+       if key == b'\x1b':
+           glut.glutDestroyWindow(window)
+
+
+   if __name__ == '__main__':
+       glut.glutInit()
+       glut.glutInitDisplayMode(glut.GLUT_DOUBLE | glut.GLUT_RGBA)
+       window = glut.glutCreateWindow('Hello World')
+       glut.glutReshapeWindow(512, 512)
+       glut.glutReshapeFunc(reshape)
+       glut.glutDisplayFunc(display)
+       glut.glutKeyboardFunc(keyboard)
+       glut.glutMainLoop()
 
 .. Note::
 


### PR DESCRIPTION
Section 3.8 Escape key handling was incorrectly using `sys.exit()` to close the window and will error when attempted to close the process. `glutDestroyWindow` needs to be called instead. Updated example code accordingly.

https://github.com/rougier/python-opengl/issues/64